### PR TITLE
Fixed repository language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go linguist-language=Go


### PR DESCRIPTION
Explicitly specified the programming language for the .go files to correct the repository language statistics.