### PR TITLE
Marked ANTLR-generated files as auto-generated.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.go linguist-language=Go
+internal/parser/*.go linguist-generated=true


### PR DESCRIPTION
Changed Linguist overrides to mark ANTLR generated files as auto-generated and not count toward language statistics.